### PR TITLE
index.html: Fix incorrect viewport separator.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <title>Synergy Milk</title>
-	<meta name="viewport" content="width=device-width; height=device-height"/>
+	<meta name="viewport" content="width=device-width, height=device-height"/>
 
     <!-- Include JS for loading Foundation libraries-->   
 	<script src="/usr/palm/frameworks/enyo/0.10/framework/enyo.js" type="text/javascript"></script>


### PR DESCRIPTION
Fixes: 
Jun 08 02:51:16 qemux86 LunaWebAppManager[576]: WARNING: 02:51:16.914: CONSOLE JS: Error parsing a meta element's content: ';' is not a valid key-value pair separator. Please use ',' instead.

Signed-off-by: Herman van Hazendonk github.com@herrie.org
